### PR TITLE
SEPE-1016: Migrate Merlin to Python 3 and fix Thruk build

### DIFF
--- a/merlin.spec
+++ b/merlin.spec
@@ -39,7 +39,7 @@ Requires: systemd
 BuildRequires: libsodium-devel
 BuildRequires: mariadb-devel
 BuildRequires: naemon-devel
-BuildRequires: python2
+BuildRequires: python39
 BuildRequires: gperf
 BuildRequires: check-devel
 BuildRequires: autoconf, automake, libtool
@@ -59,7 +59,7 @@ Requires: libaio
 Requires: merlin-apps-slim >= %version
 Requires: glib2
 BuildRequires: naemon-devel
-BuildRequires: python2
+BuildRequires: python39
 BuildRequires: gperf
 BuildRequires: check-devel
 BuildRequires: autoconf, automake, libtool
@@ -193,8 +193,8 @@ cp nrpe-merlin.cfg %buildroot%_sysconfdir/nrpe.d
 %{__install} -d %{buildroot}%{naemon_confdir}/oconf
 
 %check
-python2 tests/pyunit/test_log.py --verbose
-python2 tests/pyunit/test_oconf.py --verbose
+python3 tests/pyunit/test_log.py --verbose
+python3 tests/pyunit/test_oconf.py --verbose
 
 mkdir -p %buildroot%_localstatedir/merlin
 

--- a/thruk.spec
+++ b/thruk.spec
@@ -106,7 +106,7 @@ This package contains the reporting addon for thruk useful for sla
 and event reporting.
 
 %prep
-%setup -q -n Thruk-%{version}
+%setup -q -n thruk-%{version}
 
 %build
 export PERL5LIB=/usr/lib/thruk/perl5:/usr/lib64/thruk/perl5

--- a/thruk.spec
+++ b/thruk.spec
@@ -21,7 +21,7 @@ URL:           http://thruk.org
 Source0:       https://github.com/sni/Thruk/archive/refs/tags/v%{version}.tar.gz
 BuildRoot:     %{_tmppath}/%{name}-%{version}-%{release}
 Group:         Applications/Monitoring
-BuildRequires: autoconf, automake, perl, patch
+BuildRequires: autoconf, automake, perl, patch, npm
 Summary:       Monitoring Webinterface for Nagios/Naemon/Icinga and Shinken
 AutoReqProv:   no
 BuildRequires: libthruk >= 2.44.2
@@ -107,6 +107,38 @@ and event reporting.
 
 %prep
 %setup -q -n thruk-%{version}
+
+# Backport theme build fixes from upstream Thruk v3.26.
+# Without this, the theme Makefiles install tailwindcss@latest which pulls
+# Tailwind v4, a breaking change incompatible with the v3 config files.
+# 1) Create pinned package.json in each theme directory
+# 2) Patch the Light Makefile to read from package.json instead of @latest
+for theme_dir in themes/themes-available/Dark themes/themes-available/Light; do
+  cat > "$theme_dir/package.json" << 'PKGJSON'
+{
+  "name": "thruk-theme",
+  "devDependencies": {
+    "@tailwindcss/forms": "^0.5.10",
+    "autoprefixer": "^10.4.20",
+    "n": "^10.2.0",
+    "postcss": "^8.5.1",
+    "postcss-import": "<16.0.0",
+    "tailwindcss": "<4.0.0"
+  }
+}
+PKGJSON
+done
+# Patch Light Makefile to read deps from package.json instead of @latest.
+# Remove the explicit @latest package lines and fix the trailing backslash
+# so npm reads pinned versions from our package.json instead.
+sed -i -e '/tailwindcss@latest/d' \
+       -e '/postcss@latest/d' \
+       -e '/autoprefixer@latest/d' \
+       -e '/postcss-import@latest/d' \
+       -e '/@tailwindcss\/forms@latest/d' \
+       -e 's|--prefix=\$(shell pwd)/\. \\|--prefix=$(shell pwd)/.|' \
+       -e '/package\.json \\$/d' \
+    themes/themes-available/Light/Makefile
 
 %build
 export PERL5LIB=/usr/lib/thruk/perl5:/usr/lib64/thruk/perl5


### PR DESCRIPTION
## Summary
- **Merlin**: Migrate BuildRequires from `python2` to `python39` and update `%check` to use `python3`. The build container already has python3.9 and merlin's `configure.ac` requires it.
- **Thruk %prep fix**: GitHub archive tarballs extract to lowercase `thruk-3.20.2/` but spec had `Thruk-%{version}`.
- **Thruk theme CSS fix**: Theme Makefiles install `tailwindcss@latest` which now resolves to Tailwind v4, breaking the build. Backports pinned dependency versions from upstream Thruk v3.26.

## Test plan
- [x] All CI build jobs pass (libthruk, naemon-core, naemon, naemon-livestatus, merlin, naemon-vimvault, thruk)