### PR TITLE
SEPE-854: Upgrade naemon to 1.5.0, thruk/libthruk to 3.26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       uses: UCBoulder/oit-sepe-rpmbuild@master
       with:
         spec_file: "naemon-livestatus.spec"
-        additional_repos: '["epel-release", "/github/workspace/x86_64/libnaemon-1.4.2-0.x86_64.rpm", "/github/workspace/x86_64/naemon-devel-1.4.2-0.x86_64.rpm"]'
+        additional_repos: '["epel-release", "/github/workspace/x86_64/libnaemon-1.5.0-0.x86_64.rpm", "/github/workspace/x86_64/naemon-devel-1.5.0-0.x86_64.rpm"]'
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
@@ -76,7 +76,7 @@ jobs:
       uses: UCBoulder/oit-sepe-rpmbuild@master
       with:
         spec_file: "naemon-vimvault.spec"
-        additional_repos: '["epel-release", "/github/workspace/x86_64/libnaemon-1.4.2-0.x86_64.rpm", "/github/workspace/x86_64/naemon-devel-1.4.2-0.x86_64.rpm"]'
+        additional_repos: '["epel-release", "/github/workspace/x86_64/libnaemon-1.5.0-0.x86_64.rpm", "/github/workspace/x86_64/naemon-devel-1.5.0-0.x86_64.rpm"]'
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
@@ -99,7 +99,7 @@ jobs:
       uses: UCBoulder/oit-sepe-rpmbuild@master
       with:
         spec_file: "merlin.spec"
-        additional_repos: '["epel-release", "/github/workspace/x86_64/libnaemon-1.4.2-0.x86_64.rpm", "/github/workspace/x86_64/naemon-devel-1.4.2-0.x86_64.rpm"]'
+        additional_repos: '["epel-release", "/github/workspace/x86_64/libnaemon-1.5.0-0.x86_64.rpm", "/github/workspace/x86_64/naemon-devel-1.5.0-0.x86_64.rpm"]'
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
@@ -140,7 +140,7 @@ jobs:
       uses: UCBoulder/oit-sepe-rpmbuild@master
       with:
         spec_file: "thruk.spec"
-        additional_repos: '["epel-release", "/github/workspace/x86_64/libthruk-3.20-0.x86_64.rpm"]'
+        additional_repos: '["epel-release", "/github/workspace/x86_64/libthruk-3.26-0.x86_64.rpm"]'
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/libthruk.spec
+++ b/libthruk.spec
@@ -2,7 +2,7 @@
 
 Summary: Thruk perl libraries
 Name: libthruk
-Version: 3.20
+Version: 3.26
 Release: 0
 License: GPL-2.0-or-later
 Group: Applications/System

--- a/libthruk.spec
+++ b/libthruk.spec
@@ -11,58 +11,66 @@ Packager: Sven Nierlein <sven.nierlein@consol.de>
 Vendor: Labs Consol
 Source0: https://github.com/sni/thruk_libs/archive/refs/tags/v%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}
-BuildRequires: gd-devel > 1.8
-BuildRequires: zlib-devel
-BuildRequires: libpng-devel
-BuildRequires: libjpeg-devel
-BuildRequires: mysql-devel
 BuildRequires: perl
-BuildRequires: autoconf
-BuildRequires: automake
-BuildRequires: binutils
+BuildRequires: perl-devel
 BuildRequires: gcc
-BuildRequires: chrpath
+BuildRequires: make
 BuildRequires: rsync
-Requires: gd
+BuildRequires: perl(Bit::Vector)
+BuildRequires: perl(Cpanel::JSON::XS)
+BuildRequires: perl(Date::Calc)
+BuildRequires: perl(Digest::SHA)
+BuildRequires: perl(ExtUtils::Install)
+BuildRequires: perl(HTTP::Request)
+BuildRequires: perl(IO::Scalar)
+BuildRequires: perl(LWP::Protocol::https)
+BuildRequires: perl(LWP::UserAgent)
+BuildRequires: perl(Module::Install)
+BuildRequires: perl(XML::Parser)
 
-# sles
-%if %{defined suse_version}
-BuildRequires: libexpat-devel
-BuildRequires: fontconfig-devel
-BuildRequires: xorg-x11-libXpm-devel
-# sles 12
-%if 0%{?suse_version} >= 1315
-BuildRequires: libpng16-devel
-BuildRequires: libtiff-devel
-BuildRequires: libvpx-devel
-Requires: libjpeg62
-%else
-# sles 11
-BuildRequires: freetype2-devel
-%endif
+# epel needed for system perl modules on RHEL/Rocky/Alma
+%if 0%{?rhel} || 0%{?rocky} || 0%{?almalinux}
+BuildRequires: epel-release
 %endif
 
-# centos
-%if 0%{?el6}
-BuildRequires: perl-devel
-BuildRequires: expat-devel
-%endif
-%if 0%{?el7}
-BuildRequires: perl(Locale::Maketext::Simple)
-BuildRequires: perl-devel
-Requires: perl(Data::Dumper)
-Requires: perl(Digest)
-%endif
-%if 0%{?el8}
-BuildRequires: perl-devel
-BuildRequires: expat-devel
-%endif
-
-# fedora
-%if 0%{?fedora}
-BuildRequires: perl-devel
-BuildRequires: expat-devel
-%endif
+# v3.26 uses system perl modules instead of bundling them
+Requires: perl(Bit::Vector)
+Requires: perl(Cpanel::JSON::XS)
+Requires: perl(Crypt::Rijndael)
+Requires: perl(Date::Calc)
+Requires: perl(Date::Manip)
+Requires: perl(DBD::mysql)
+Requires: perl(DBI)
+Requires: perl(FCGI)
+Requires: perl(GD)
+Requires: perl(HTML::Entities)
+Requires: perl(HTTP::Request)
+Requires: perl(IO::Scalar)
+Requires: perl(IO::Socket::IP)
+Requires: perl(IO::Socket::SSL)
+Requires: perl(IO::String)
+Requires: perl(Log::Log4perl)
+Requires: perl(LWP::Protocol::https)
+Requires: perl(LWP::UserAgent)
+Requires: perl(MIME::Lite)
+Requires: perl(Module::Load)
+Requires: perl(Net::HTTP)
+Requires: perl(Net::SSLeay)
+Requires: perl(parent)
+Requires: perl(Plack)
+Requires: perl(Plack::Handler::FCGI)
+Requires: perl(Plack::Util)
+Requires: perl(Plack::Test)
+Requires: perl(Pod::Usage)
+Requires: perl(Socket)
+Requires: perl(Storable)
+Requires: perl(Template)
+Requires: perl(Thread::Queue)
+Requires: perl(threads)
+Requires: perl(Tie::IxHash)
+Requires: perl(Time::HiRes)
+Requires: perl(URI::Escape)
+Requires: perl(XML::Parser)
 
 # disable creating useless empty debug packages
 %define debug_package %{nil}
@@ -86,9 +94,6 @@ large installations.
 %install
 %{__rm} -rf %{buildroot}
 %{__make} install DESTDIR="%{buildroot}" LIBDIR="%{_libdir}/thruk/"
-%if %{defined suse_version}
-%{__make} installbuilddeps DESTDIR="%{buildroot}" LIBDIR="%{_libdir}/thruk/"
-%endif
 
 %clean
 %{__rm} -rf %{buildroot}
@@ -102,4 +107,3 @@ large installations.
 
 * Mon Jul 13 2015 Sven Nierlein <sven.nierlein@consol.de> 2.00-1
 - Initial libs package
-

--- a/naemon-core.spec
+++ b/naemon-core.spec
@@ -4,7 +4,7 @@
 
 Summary: Open Source Host, Service And Network Monitoring Program
 Name: naemon-core
-Version: 1.4.2
+Version: 1.5.0
 Release: 0
 License: GPL-2.0-only
 Group: Applications/System

--- a/naemon-livestatus.spec
+++ b/naemon-livestatus.spec
@@ -2,7 +2,7 @@
 
 Summary: Naemon Livestatus Eventbroker Module
 Name: naemon-livestatus
-Version: 1.4.2
+Version: 1.5.0
 Release: 0
 License: GPL-2.0-only
 Group: Applications/System

--- a/naemon-vimvault.spec
+++ b/naemon-vimvault.spec
@@ -2,7 +2,7 @@
 
 Summary: Naemon VimVault Eventbroker Module
 Name: naemon-vimvault
-Version: 1.4.2
+Version: 1.5.0
 Release: 0
 License: GPL-3.0-or-later
 Group: Applications/System

--- a/naemon.spec
+++ b/naemon.spec
@@ -12,7 +12,7 @@
 
 Summary: Open Source Host, Service And Network Monitoring Program
 Name: naemon
-Version: 1.4.2
+Version: 1.5.0
 Release: 0
 License: GPL-2.0-only
 BuildArch: noarch

--- a/thruk.spec
+++ b/thruk.spec
@@ -24,7 +24,7 @@ Group:         Applications/Monitoring
 BuildRequires: autoconf, automake, perl, patch, npm
 Summary:       Monitoring Webinterface for Nagios/Naemon/Icinga and Shinken
 AutoReqProv:   no
-BuildRequires: libthruk >= 2.44.2
+BuildRequires: libthruk >= 3.24
 Requires:      thruk-base = %{version}-%{release}
 Requires:      thruk-plugin-reporting = %{version}-%{release}
 %if 0%{?suse_version} < 1315
@@ -50,7 +50,7 @@ large installations.
 %package base
 Summary:     Thruk Gui Base Files
 Group:       Applications/System
-Requires:    libthruk >= 2.44.2
+Requires:    libthruk >= 3.24
 Requires(preun): libthruk
 Requires(post): libthruk
 Requires:    perl logrotate gd wget

--- a/thruk.spec
+++ b/thruk.spec
@@ -131,6 +131,9 @@ export PERL5LIB=/usr/lib/thruk/perl5:/usr/lib64/thruk/perl5
 # make sure themes are built as this point
 test -f themes/themes-available/Light/stylesheets/Light.css || %{__make} themes
 test -f themes/themes-available/Light/stylesheets/Light.css || exit 1
+# generate combined static content (panorama JS cache)
+test -f root/thruk/cache/thruk-panorama-*.js || perl script/thruk_create_combined_static_content.pl
+test -f root/thruk/cache/thruk-panorama-*.js || exit 1
 
 # replace /usr/bin/env according to https://fedoraproject.org/wiki/Packaging:Guidelines#Shebang_lines
 sed -e 's%/usr/bin/env perl%/usr/bin/perl%' -i \

--- a/thruk.spec
+++ b/thruk.spec
@@ -11,8 +11,8 @@
 %undefine _disable_source_fetch
 
 Name:          thruk
-Version:       3.20.2
-Release:       13569.1
+Version:       3.26
+Release:       14286.1
 License:       GPL-2.0-or-later
 Packager:      Sven Nierlein <sven.nierlein@consol.de>
 Vendor:        Labs Consol
@@ -107,38 +107,6 @@ and event reporting.
 
 %prep
 %setup -q -n thruk-%{version}
-
-# Backport theme build fixes from upstream Thruk v3.26.
-# Without this, the theme Makefiles install tailwindcss@latest which pulls
-# Tailwind v4, a breaking change incompatible with the v3 config files.
-# 1) Create pinned package.json in each theme directory
-# 2) Patch the Light Makefile to read from package.json instead of @latest
-for theme_dir in themes/themes-available/Dark themes/themes-available/Light; do
-  cat > "$theme_dir/package.json" << 'PKGJSON'
-{
-  "name": "thruk-theme",
-  "devDependencies": {
-    "@tailwindcss/forms": "^0.5.10",
-    "autoprefixer": "^10.4.20",
-    "n": "^10.2.0",
-    "postcss": "^8.5.1",
-    "postcss-import": "<16.0.0",
-    "tailwindcss": "<4.0.0"
-  }
-}
-PKGJSON
-done
-# Patch Light Makefile to read deps from package.json instead of @latest.
-# Remove the explicit @latest package lines and fix the trailing backslash
-# so npm reads pinned versions from our package.json instead.
-sed -i -e '/tailwindcss@latest/d' \
-       -e '/postcss@latest/d' \
-       -e '/autoprefixer@latest/d' \
-       -e '/postcss-import@latest/d' \
-       -e '/@tailwindcss\/forms@latest/d' \
-       -e 's|--prefix=\$(shell pwd)/\. \\|--prefix=$(shell pwd)/.|' \
-       -e '/package\.json \\$/d' \
-    themes/themes-available/Light/Makefile
 
 %build
 export PERL5LIB=/usr/lib/thruk/perl5:/usr/lib64/thruk/perl5

--- a/thruk.spec
+++ b/thruk.spec
@@ -460,6 +460,8 @@ exit 0
 %config %{_sysconfdir}/%{name}/plugins/plugins-available/editor
 %{_datadir}/%{name}/plugins/plugins-available/node-control
 %config %{_sysconfdir}/%{name}/plugins/plugins-available/node-control
+%{_datadir}/%{name}/plugins/plugins-available/omd
+%config %{_sysconfdir}/%{name}/plugins/plugins-available/omd
 %config(noreplace) %{_sysconfdir}/thruk/themes
 %config(noreplace) %{_sysconfdir}/thruk/menu_local.conf
 %config(noreplace) %{_sysconfdir}/thruk/usercontent/
@@ -475,6 +477,7 @@ exit 0
 %attr(0755,root,root) %{_datadir}/thruk/script/pnp_export.sh
 %attr(0755,root,root) %{_datadir}/thruk/script/convert_old_datafile
 %attr(0755,root,root) %{_datadir}/thruk/script/check_thruk_rest
+%attr(0755,root,root) %{_datadir}/thruk/script/check_thruk_rest.sh
 %{_datadir}/thruk/support
 %{_datadir}/thruk/root
 %{_datadir}/thruk/templates


### PR DESCRIPTION
## Summary
- Bump naemon-core, naemon, naemon-livestatus, naemon-vimvault from 1.4.2 to 1.5.0
- Bump thruk and libthruk from 3.20.x to 3.26
- Rewrite libthruk.spec for v3.26's migration from bundled perl modules to system packages (37 new Requires from EPEL)
- Update thruk.spec: add omd plugin, check_thruk_rest.sh, explicit panorama JS generation, remove old CU CSS patches (now upstream)
- Update build.yml RPM filename references

## Test plan
- [x] All 7 CI build jobs pass (naemon-core, libthruk, naemon, thruk, naemon-vimvault, merlin, naemon-livestatus)
- [ ] Tag as cub-0.2.0 after merge to trigger publish-rpms
- [ ] Deploy to dev cluster via oit-sepe-naemon-infra