### PR TITLE
SEPE-854: Bump merlin release for naemon 1.5.0 ABI compatibility

### DIFF
--- a/merlin.spec
+++ b/merlin.spec
@@ -20,7 +20,7 @@
 Summary: The merlin daemon is a multiplexing event-transport program
 Name: merlin
 Version: 2024.10.14
-Release: 0
+Release: 1
 License: GPLv2
 URL: https://github.com/ITRS-Group/monitor-merlin/
 Source0: https://github.com/ITRS-Group/monitor-merlin/archive/refs/tags/v%{version}.tar.gz


### PR DESCRIPTION
## Summary
- Bump merlin Release from 0 to 1
- Merlin NEB module must be rebuilt against naemon 1.5.0 headers (event broker API v8 vs v6)
- Without this, naemon 1.5.0 refuses to load merlin.so: `Module is using an incompatible version (v6) of the event broker API (current version: v8)`
- The version bump ensures dnf treats it as an upgrade over the previous build

## Test plan
- [x] CI build passes
- [ ] Tag as cub-0.2.1, deploy to test, verify naemon starts with merlin loaded