### PR TITLE
SEPE-1041: Convert merlin check_timeout fix from sed to patch file

### DIFF
--- a/merlin-0001-check_timeout-naemon-1.5.1.patch
+++ b/merlin-0001-check_timeout-naemon-1.5.1.patch
@@ -1,0 +1,48 @@
+From 41f0d3857a429dfb92b222326cafcc702c3f91f8 Mon Sep 17 00:00:00 2001
+From: Eric Schoeller <schoelle@colorado.edu>
+Date: Thu, 19 Mar 2026 17:48:57 -0600
+Subject: [PATCH] Fix compilation against naemon-core 1.5.1
+
+Naemon-core 1.5.1 adds a check_timeout parameter to both
+setup_host_variables() and setup_service_variables(). The new field
+is inserted after initial_state in the host and service structs.
+
+Without this fix, merlin fails to compile against naemon-core 1.5.1:
+
+  module/oconfsplit.c:222:3: error: too few arguments to function
+  'setup_service_variables'
+
+Add h->check_timeout and s->check_timeout to the respective function
+calls in oconfsplit.c.
+
+Also fixes a minor whitespace issue in the setup_host_variables call
+(h-> initial_state -> h->initial_state).
+
+Ref: https://www.naemon.io/news/2026-03-19-release-1.5.1
+Ref: https://github.com/naemon/naemon-core/releases/tag/v1.5.1
+---
+ module/oconfsplit.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/module/oconfsplit.c b/module/oconfsplit.c
+index e6ff9e5a..672c5fb1 100644
+--- a/module/oconfsplit.c
++++ b/module/oconfsplit.c
+@@ -194,7 +194,7 @@ static gboolean nsplit_cache_host(gpointer _name, gpointer _hst, __attribute__((
+ 	nsplit_cache_slaves(h);
+ 
+ 	tmphst = create_host(h->name);
+-	setup_host_variables(tmphst, h->display_name, h->alias, h->address, h->check_period, h-> initial_state, h->check_interval, h->retry_interval, h->max_attempts, h->notification_options, h->notification_interval, h->first_notification_delay, h->notification_period, h->notifications_enabled, h->check_command, h->checks_enabled, h->accept_passive_checks, h->event_handler, h->event_handler_enabled, h->flap_detection_enabled, h->low_flap_threshold, h->high_flap_threshold, h->flap_detection_options, h->stalking_options, h->process_performance_data, h->check_freshness, h->freshness_threshold, h->notes, h->notes_url, h->action_url, h->icon_image, h->icon_image_alt, h->vrml_image, h->statusmap_image, h->x_2d, h->y_2d, h->have_2d_coords, h->x_3d, h->y_3d, h->z_3d, h->have_3d_coords, h->retain_status_information, h->retain_nonstatus_information, h->obsess, h->hourly_value);
++	setup_host_variables(tmphst, h->display_name, h->alias, h->address, h->check_period, h->initial_state, h->check_timeout, h->check_interval, h->retry_interval, h->max_attempts, h->notification_options, h->notification_interval, h->first_notification_delay, h->notification_period, h->notifications_enabled, h->check_command, h->checks_enabled, h->accept_passive_checks, h->event_handler, h->event_handler_enabled, h->flap_detection_enabled, h->low_flap_threshold, h->high_flap_threshold, h->flap_detection_options, h->stalking_options, h->process_performance_data, h->check_freshness, h->freshness_threshold, h->notes, h->notes_url, h->action_url, h->icon_image, h->icon_image_alt, h->vrml_image, h->statusmap_image, h->x_2d, h->y_2d, h->have_2d_coords, h->x_3d, h->y_3d, h->z_3d, h->have_3d_coords, h->retain_status_information, h->retain_nonstatus_information, h->obsess, h->hourly_value);
+ 
+ 	g_tree_foreach(h->parent_hosts, copy_relevant_parents, tmphst);
+ 	for (cm = h->contacts; cm; cm = cm->next)
+@@ -219,7 +219,7 @@ static gboolean nsplit_cache_host(gpointer _name, gpointer _hst, __attribute__((
+ 	for (sm = h->services; sm; sm = sm->next) {
+ 		struct service *s = sm->service_ptr;
+ 		struct service *tmpsvc = create_service(tmphst, s->description);
+-		setup_service_variables(tmpsvc, s->display_name, s->check_command, s->check_period, s->initial_state, s->max_attempts, s->accept_passive_checks, s->check_interval, s->retry_interval, s->notification_interval, s->first_notification_delay, s->notification_period, s->notification_options, s->notifications_enabled, s->is_volatile, s->event_handler, s->event_handler_enabled, s->checks_enabled, s->flap_detection_enabled, s->low_flap_threshold, s->high_flap_threshold, s->flap_detection_options, s->stalking_options, s->process_performance_data, s->check_freshness, s->freshness_threshold, s->notes, s->notes_url, s->action_url, s->icon_image, s->icon_image_alt, s->retain_status_information, s->retain_nonstatus_information, s->obsess, s->hourly_value);
++		setup_service_variables(tmpsvc, s->display_name, s->check_command, s->check_period, s->initial_state, s->check_timeout, s->max_attempts, s->accept_passive_checks, s->check_interval, s->retry_interval, s->notification_interval, s->first_notification_delay, s->notification_period, s->notification_options, s->notifications_enabled, s->is_volatile, s->event_handler, s->event_handler_enabled, s->checks_enabled, s->flap_detection_enabled, s->low_flap_threshold, s->high_flap_threshold, s->flap_detection_options, s->stalking_options, s->process_performance_data, s->check_freshness, s->freshness_threshold, s->notes, s->notes_url, s->action_url, s->icon_image, s->icon_image_alt, s->retain_status_information, s->retain_nonstatus_information, s->obsess, s->hourly_value);
+ 		for (cm = s->contacts; cm; cm = cm->next)
+ 			add_contact_to_service(tmpsvc, cm->contact_name);
+ 		for (cgm = s->contact_groups; cgm; cgm = cgm->next)

--- a/merlin.spec
+++ b/merlin.spec
@@ -20,10 +20,19 @@
 Summary: The merlin daemon is a multiplexing event-transport program
 Name: merlin
 Version: 2024.10.14
-Release: 2
+Release: 3
 License: GPLv2
 URL: https://github.com/ITRS-Group/monitor-merlin/
 Source0: https://github.com/ITRS-Group/monitor-merlin/archive/refs/tags/v%{version}.tar.gz
+
+# TEMPORARY: Patch for naemon 1.5.1 check_timeout API change.
+# Remove this Patch0 declaration and the %patch0 invocation below when
+# merlin releases a version that includes the fix. Also bump Version/
+# Release and update the merlin dependency filenames in build.yml at
+# that time.
+# Upstream PR: https://github.com/ITRS-Group/monitor-merlin/pull/174
+Patch0: merlin-0001-check_timeout-naemon-1.5.1.patch
+
 BuildRoot: %{_tmppath}/monitor-%{name}-%{version}
 Requires: libaio
 Requires: merlin-apps >= %version
@@ -162,12 +171,7 @@ network monitoring setup.
 
 %prep
 %setup -q -n monitor-%{name}-%{version}
-
-# Patch for naemon 1.5.1: add check_timeout parameter to setup_host_variables
-# and setup_service_variables calls in oconfsplit.c
-sed -i 's/h->check_period, h-> initial_state, h->check_interval/h->check_period, h->initial_state, h->check_timeout, h->check_interval/' module/oconfsplit.c
-sed -i 's/s->initial_state, s->max_attempts/s->initial_state, s->check_timeout, s->max_attempts/' module/oconfsplit.c
-grep -q 'check_timeout' module/oconfsplit.c || { echo "ERROR: check_timeout patch did not apply"; exit 1; }
+%patch0 -p1
 
 %build
 echo %{version} > .version_number


### PR DESCRIPTION
## Summary

- Replace the inline \`sed\` substitutions in \`merlin.spec %prep\` with a proper \`Patch0:\` declaration that references \`merlin-0001-check_timeout-naemon-1.5.1.patch\` in the repo root.
- Bump merlin \`Release\` from 2 to 3 so \`dnf\` picks up the rebuilt RPM.

This is a mechanical refactor — the binary output is identical to cub-0.3.0's merlin RPM, just expressed as a clean diff instead of sed.

## Why

\`sed\` composition does not scale for multiple patches and silently breaks if upstream changes the line format. A second merlin patch (upstream PR ITRS-Group/monitor-merlin#175) is queued behind this one, and we need a proper mechanism. oit-sepe-rpmbuild now supports this via UCBoulder/oit-sepe-rpmbuild#1, which copies \`*.patch\` files from the repo root into the rpmbuild \`SOURCES\` directory before invoking \`rpmbuild\`. That work was tracked under SEPE-1058.

## Patch provenance

The patch file is the output of \`curl https://github.com/ITRS-Group/monitor-merlin/pull/174.patch\` — my own upstream PR against \`ITRS-Group/monitor-merlin\`. It's still open pending upstream review/Buildbot CI, so we continue to carry it locally.

## Test plan

- [ ] CI builds all packages cleanly on this branch
- [ ] Tag cub-0.3.1 after merge and verify the release artifacts contain \`merlin-2024.10.14-3.x86_64.rpm\`
- [ ] Deploy to naemon-test via \`oit-sepe-naemon-infra\` bump and verify merlin peering still works