### PR TITLE
SEPE-1059: Bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
   build-naemon-core:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: build Naemon core packages
       id: build 
@@ -15,7 +15,7 @@ jobs:
         additional_repos: '["epel-release"]'
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Naemon Core RPMs
         path: ${{ steps.build.outputs.rpm_dir_path }}
@@ -23,7 +23,7 @@ jobs:
   build-naemon:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: build Naemon packages
       id: build
@@ -33,7 +33,7 @@ jobs:
         additional_repos: '["epel-release"]'
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Naemon RPMs
         path: ${{ steps.build.outputs.rpm_dir_path }}
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-naemon-core
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: Naemon Core RPMs
 
@@ -56,7 +56,7 @@ jobs:
         additional_repos: '["epel-release", "/github/workspace/x86_64/libnaemon-1.5.1-0.x86_64.rpm", "/github/workspace/x86_64/naemon-devel-1.5.1-0.x86_64.rpm"]'
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Naemon Livestatus RPMs
         path: ${{ steps.build.outputs.rpm_dir_path }}
@@ -65,9 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-naemon-core
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: Naemon Core RPMs
 
@@ -79,7 +79,7 @@ jobs:
         additional_repos: '["epel-release", "/github/workspace/x86_64/libnaemon-1.5.1-0.x86_64.rpm", "/github/workspace/x86_64/naemon-devel-1.5.1-0.x86_64.rpm"]'
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Naemon Vimvault RPMs
         path: ${{ steps.build.outputs.rpm_dir_path }}
@@ -88,9 +88,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-naemon-core
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: Naemon Core RPMs
 
@@ -102,7 +102,7 @@ jobs:
         additional_repos: '["epel-release", "/github/workspace/x86_64/libnaemon-1.5.1-0.x86_64.rpm", "/github/workspace/x86_64/naemon-devel-1.5.1-0.x86_64.rpm"]'
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Merlin RPMs
         path: ${{ steps.build.outputs.rpm_dir_path }}
@@ -110,7 +110,7 @@ jobs:
   build-libthruk:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: build Libthruk packages
       id: build
@@ -120,7 +120,7 @@ jobs:
         additional_repos: '["epel-release"]'
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Libthruk RPMs
         path: ${{ steps.build.outputs.rpm_dir_path }}
@@ -129,9 +129,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-libthruk
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: Libthruk RPMs
 
@@ -143,7 +143,7 @@ jobs:
         additional_repos: '["epel-release", "/github/workspace/x86_64/libthruk-3.26-0.x86_64.rpm"]'
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Thruk RPMs
         path: ${{ steps.build.outputs.rpm_dir_path }}
@@ -160,7 +160,7 @@ jobs:
       - build-thruk
       - build-merlin
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         merge-multiple: True
 


### PR DESCRIPTION
## Summary

Bump the three Node.js 20 GitHub Actions used by the build workflow to their latest Node.js 24 compatible versions:

- \`actions/checkout@v4\` → \`v6\`
- \`actions/upload-artifact@v4\` → \`v7\`
- \`actions/download-artifact@v4\` → \`v8\`

\`ncipollo/release-action@v1\` is unaffected (not Node.js based).

## Why

GitHub is deprecating Node.js 20 on its runners:

- **2026-06-02:** Forced migration — runner will push actions onto Node.js 24
- **2026-09-16:** Node.js 20 removed from runners entirely

Every build currently prints a deprecation warning. This PR resolves it ahead of the forced migration.

## Test plan

- [ ] All 7 package build jobs pass on this branch
- [ ] No Node.js 20 deprecation warnings in the build output