### PR TITLE
SEPE-1064: Remove dead code from merlin.spec %post for non-DB deployments

### DIFF
--- a/merlin.spec
+++ b/merlin.spec
@@ -342,7 +342,7 @@ systemctl restart naemon || :
 rm -rf %buildroot
 
 %changelog
-* Wed Apr 09 2026 Eric Schoeller <eric.schoeller@colorado.edu>
+* Thu Apr 09 2026 Eric Schoeller <eric.schoeller@colorado.edu>
 - SEPE-1064: Remove dead code from %post (DB, log import, sed, nrpe restart)
 - Stop installing nrpe-merlin.cfg (references non-existent /opt/plugins/ paths)
 - Bump Release to 4

--- a/merlin.spec
+++ b/merlin.spec
@@ -195,8 +195,10 @@ cp cukemerlin %buildroot/%_bindir/cukemerlin
 cp -r apps/tests %buildroot/usr/share/merlin/app-tests
 
 
-mkdir -p %buildroot%_sysconfdir/nrpe.d
-cp nrpe-merlin.cfg %buildroot%_sysconfdir/nrpe.d
+# nrpe-merlin.cfg intentionally NOT installed. The commands it defines
+# reference /opt/plugins/ paths from the upstream op5 Monitor distribution
+# that don't exist in our environment. Our naemon/merlin NRPE checks are
+# deployed via Ansible in check_naemon.cfg instead.
 
 %{__install} -D -m 644 merlind.service %{buildroot}%{_unitdir}/merlind.service
 # Ensure oconf dir exists
@@ -249,7 +251,6 @@ systemctl restart naemon || :
 %_bindir/merlind
 %_libdir/merlin/install-merlin.sh
 %_sysconfdir/logrotate.d/merlin
-%_sysconfdir/nrpe.d/nrpe-merlin.cfg
 %{_unitdir}/merlind.service
 %attr(-, %daemon_user, %daemon_group) %dir %_localstatedir/lib/merlin
 %attr(775, %daemon_user, %daemon_group) %dir %_localstatedir/lib/merlin/binlogs
@@ -302,7 +303,6 @@ systemctl restart naemon || :
 %_bindir/merlind
 %_libdir/merlin/install-merlin.sh
 %_sysconfdir/logrotate.d/merlin
-%_sysconfdir/nrpe.d/nrpe-merlin.cfg
 %attr(-, %daemon_user, %daemon_group) %dir %_localstatedir/lib/merlin
 %attr(775, %daemon_user, %daemon_group) %dir %_localstatedir/lib/merlin/binlogs
 %attr(-, %daemon_user, %daemon_group) %dir %_localstatedir/log/merlin

--- a/merlin.spec
+++ b/merlin.spec
@@ -239,8 +239,6 @@ fi
 
 %post -n monitor-merlin
 systemctl restart naemon || :
-# nrpe restart removed — unnecessary; nrpe picks up the
-# nrpe-merlin.cfg drop-in without a full restart.
 
 %files
 %defattr(-,root,root)
@@ -342,6 +340,10 @@ systemctl restart naemon || :
 rm -rf %buildroot
 
 %changelog
+* Wed Apr 09 2026 Eric Schoeller <eric.schoeller@colorado.edu>
+- SEPE-1064: Remove dead code from %post (DB, log import, sed, nrpe restart)
+- Stop installing nrpe-merlin.cfg (references non-existent /opt/plugins/ paths)
+- Bump Release to 4
 * Thu Feb 08 2024 Will Haines <william.haines@colorado.edu>
 - Fork for CU Boulder
 * Thu Feb 11 2021 Aksel Sjögren <asjogren@itrsgroup.com>

--- a/merlin.spec
+++ b/merlin.spec
@@ -223,8 +223,8 @@ getent group %operator_group > /dev/null || groupadd %operator_group
 # Restart merlind to pick up the new binary. In managed (Ansible)
 # deployments, the playbook masks merlind before install so this
 # restart is a no-op — the playbook handles the restart sequence
-# in launch.yml to avoid ABI mismatch between the in-memory
-# merlin.so (loaded by naemon) and the on-disk merlind binary.
+# to avoid ABI mismatch between the in-memory merlin.so (loaded
+# by naemon) and the on-disk merlind binary.
 # For standalone installs, this restart is the right thing to do.
 systemctl restart merlind || :
 
@@ -234,8 +234,10 @@ if [ $1 -eq 0 ]; then
 fi
 
 %postun -n monitor-merlin
-# nrpe restart removed — nrpe picks up config changes on reload,
-# and the merlin package uninstall doesn't require an nrpe bounce.
+# Intentionally empty — the nrpe restart that was here was removed
+# because nrpe picks up config changes on reload and the merlin
+# package uninstall doesn't require an nrpe bounce.
+:
 
 %post -n monitor-merlin
 systemctl restart naemon || :

--- a/merlin.spec
+++ b/merlin.spec
@@ -20,7 +20,7 @@
 Summary: The merlin daemon is a multiplexing event-transport program
 Name: merlin
 Version: 2024.10.14
-Release: 3
+Release: 4
 License: GPLv2
 URL: https://github.com/ITRS-Group/monitor-merlin/
 Source0: https://github.com/ITRS-Group/monitor-merlin/archive/refs/tags/v%{version}.tar.gz
@@ -210,54 +210,21 @@ mkdir -p %buildroot%_localstatedir/merlin
 
 %post
 systemctl daemon-reload
-# we must stop the merlin deamon so it doesn't interfere with any
-# database upgrades, logfile imports and whatnot
-systemctl stop merlind > /dev/null || :
-
-# Verify that mysql-server is installed and running before executing sql scripts
-systemctl is-active %mysqld 2&>1 >/dev/null
-
-if [ $? -gt 0 ]; then
-  echo "Attempting to start %mysqld..."
-  systemctl start %mysqld
-  if [ $? -gt 0 ]; then
-    echo "Abort: Failed to start %mysqld."
-    exit 1
-  fi
-fi
-
-if ! mysql -umerlin -pmerlin merlin -e 'show tables' > /dev/null 2>&1; then
-    mysql -uroot -e "CREATE DATABASE IF NOT EXISTS merlin"
-    mysql -uroot -e "GRANT ALL ON merlin.* TO merlin@localhost IDENTIFIED BY 'merlin'"
-fi
-%_libdir/merlin/install-merlin.sh
-
 systemctl enable merlind.service
-
-# If mysql-server is running _or_ this is an upgrade
-# we import logs
-if [ $1 -eq 2 ]; then
-  mon log import --incremental > /dev/null 2>&1 || :
-  mon log import --only-notifications --incremental > /dev/null 2>&1 || :
-fi
-
-sed --follow-symlinks -i \
-    -e 's#pidfile =.*$#pidfile = /var/run/merlin/merlin.pid;#' \
-    -e 's#log_file =.*neb\.log;$#log_file = %{_localstatedir}/log/merlin/neb.log;#' \
-    -e 's#log_file =.*daemon\.log;$#log_file = %{_localstatedir}/log/merlin/daemon.log;#' \
-    -e 's#ipc_socket =.*$#ipc_socket = /var/lib/merlin/ipc.sock;#' \
-    %mod_path/merlin.conf
 
 # chown old cached nodesplit data, so it can be deleted
 chown -R %daemon_user:%daemon_group %_localstatedir/cache/merlin
 
-# restart all daemons
-for daemon in merlind nrpe; do
-    systemctl restart $daemon
-done
-
 # Create operator group for use in sudoers
 getent group %operator_group > /dev/null || groupadd %operator_group
+
+# Restart merlind to pick up the new binary. In managed (Ansible)
+# deployments, the playbook masks merlind before install so this
+# restart is a no-op — the playbook handles the restart sequence
+# in launch.yml to avoid ABI mismatch between the in-memory
+# merlin.so (loaded by naemon) and the on-disk merlind binary.
+# For standalone installs, this restart is the right thing to do.
+systemctl restart merlind || :
 
 %preun -n monitor-merlin
 if [ $1 -eq 0 ]; then

--- a/merlin.spec
+++ b/merlin.spec
@@ -209,8 +209,8 @@ python3 tests/pyunit/test_oconf.py --verbose
 mkdir -p %buildroot%_localstatedir/merlin
 
 %post
-systemctl daemon-reload
-systemctl enable merlind.service
+systemctl daemon-reload || :
+systemctl enable merlind.service || :
 
 # chown old cached nodesplit data, so it can be deleted
 chown -R %daemon_user:%daemon_group %_localstatedir/cache/merlin
@@ -232,13 +232,13 @@ if [ $1 -eq 0 ]; then
 fi
 
 %postun -n monitor-merlin
-if [ $1 -eq 0 ]; then
-    systemctl restart nrpe || :
-fi
+# nrpe restart removed — nrpe picks up config changes on reload,
+# and the merlin package uninstall doesn't require an nrpe bounce.
 
 %post -n monitor-merlin
 systemctl restart naemon || :
-systemctl restart nrpe || :
+# nrpe restart removed — unnecessary; nrpe picks up the
+# nrpe-merlin.cfg drop-in without a full restart.
 
 %files
 %defattr(-,root,root)


### PR DESCRIPTION
## Summary
Removes dead code from merlin.spec `%post` that is irrelevant to our deployment (no merlin database):

- `systemctl stop merlind` (only existed to protect DB operations)
- MySQL/mariadb health check and conditional start
- Database create + grant
- `install-merlin.sh` schema migration
- `mon log import` (DB-backed log importer)
- `sed` on `merlin.conf` (overwritten by Ansible immediately after install)
- `nrpe` restart (unnecessary; nrpe picks up config changes on SIGHUP)

Keeps: `daemon-reload`, `enable merlind`, `chown` cache dir, `groupadd mon_operators`, and a final `systemctl restart merlind || :` with documentation explaining how the Ansible playbook masks merlind during managed upgrades so the restart is a no-op.

Bump Release 3 -> 4.

## Test plan
- [ ] Build the RPM on the CI pipeline (tag a test release)
- [ ] Deploy to naemon-test: verify `%post` runs cleanly with no DB errors, no nrpe restart, no sed edits
- [ ] Verify merlind restarts correctly on standalone install (no masking)
- [ ] Verify merlind stays running when masked during a managed (Ansible) upgrade